### PR TITLE
fix: update domain name for generated images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ["oaidalleapiprodscus.blob.core.windows.net", "https://genz.ad"],
+    domains: ["oaidalleapiprodscus.blob.core.windows.net", "genz.ad"],
   },
 };
 


### PR DESCRIPTION
Replace "https://genz.ad" with "genz.ad" in next.config.ts
