### PR TITLE
fix: fix popup showing when limit is still available in v1.2

### DIFF
--- a/src/domains/ads-gen/components/image-ad-form.tsx
+++ b/src/domains/ads-gen/components/image-ad-form.tsx
@@ -90,7 +90,7 @@ export const ImageAdForm = () => {
   const [isFormLoaded, setIsFormLoaded] = useState(false);
   const [allRequiredFieldsFilled, setAllRequiredFieldsFilled] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [limitReached, setLimitReached] = useState(true)
+  const [limitReached, setLimitReached] = useState(false)
   const [limits, setLimits] = useState('')
 
 


### PR DESCRIPTION
I fixed the pop up showing when limit is still available