### PR TITLE
fix: Fixed z-index bug causing X button to be unclickable.

### DIFF
--- a/src/components/ui/mobile-multi-select.tsx
+++ b/src/components/ui/mobile-multi-select.tsx
@@ -157,7 +157,7 @@ const MobileMultiSelect = ({
           side="bottom"
           className="px-0 py-0 h-auto max-h-[60vh] rounded-t-xl"
         >
-          <SheetHeader className="px-8 py-5 sticky top-0 bg-transparent z-10">
+          <SheetHeader className="px-8 py-5 sticky top-0 bg-transparent">
             <SheetTitle className="font-medium">{title}</SheetTitle>
           </SheetHeader>
 


### PR DESCRIPTION
### Title:
fix: Fixed z-index issue causing X button to be unclickable in mobile view.

**Description:**

This PR resolves a UI bug where the z-index stacking order was causing the X button to be covered by other elements, rendering it unclickable. The fix ensures that the button is correctly layered on top, restoring its intended functionality.

**Changes Included:**

Removed the z-index value in the `SheetHeader`  to ensure it is not overlapping elements.

**Testing:**

Opened the affected modal/component and confirmed the X button is now visible and clickable.