### PR TITLE
fix: back button rerouting wrongly

### DIFF
--- a/src/domains/ads-gen/components/ad-generation-progress.tsx
+++ b/src/domains/ads-gen/components/ad-generation-progress.tsx
@@ -36,7 +36,7 @@ const AdGenerationProgress: React.FC = () => {
 
   return (
     <div className="max-w-[1280px] w-full py-2">
-      <BackButton />
+      <BackButton fallbackUrl="/generate-ad" />
       <div className="w-full flex max-lg:flex-col gap-10 justify-between">
         <div className="max-w-[540px] w-full ">
           <h2 className="text-[32px] text-[#121316] leading-10 font-semibold">

--- a/src/domains/ads-gen/components/back-button.tsx
+++ b/src/domains/ads-gen/components/back-button.tsx
@@ -18,14 +18,7 @@ const BackButton: React.FC<BackButtonProps> = ({
   const router = useRouter();
 
   const handleBack = () => {
-    try {
-      // Set a flag in sessionStorage to indicate we're navigating back
-      sessionStorage.setItem("navigatingBack", "true");
-      router.back();
-    } catch {
-      // If back navigation fails, go to fallback URL
-      router.push(fallbackUrl);
-    }
+    router.push(fallbackUrl);
   };
 
   return (

--- a/src/domains/ads-gen/components/prompt-selection.tsx
+++ b/src/domains/ads-gen/components/prompt-selection.tsx
@@ -148,7 +148,7 @@ const PromptSelection: React.FC<PromptSelectionProps> = ({
 
   return (
     <div className="flex flex-col gap-10">
-      <BackButton />
+      <BackButton fallbackUrl="/"/>
       <CardHeader className="text-center px-0 mt-[15px]">
         <CardTitle className="text-[28px] leading-[36px] text-[#121316] font-semibold">
           Generate Your Image Ad for Free


### PR DESCRIPTION
### PR Title:
fix: ensure back button navigates correctly after selecting a predefined prompt

**Description**

This PR fixes an issue where the `Back button` in the `Predefined Prompts` screen does not correctly return to `Home `after a prompt has been selected for generation.

**Issue Summary:**

- ✅ The Back button in Preview correctly returns to Predefined Prompts.
- ❌ The Back button in Predefined Prompts does not return to Home after selecting a predefined prompt.

Changes Included:

**Updated `BackButton` component:**

1. Added a `fallbackUrl` prop to define a default navigation route.
2. Removed the session storage flag logic that attempted to track back navigation.
3. Simplified the handleBack function to ensure reliable fallback navigation.
4. Modified usage in `PromptSelection.tsx`: assed `fallbackUrl="/"` to ensure the Back button in predefined prompts correctly returns to `Home`.
5. Adjusted usage in other components: Set `fallbackUrl="/generate-ad"` where necessary for correct navigation behavior.

**Testing:**

- Verified that after selecting a predefined prompt, the Back button in `Predefined Prompts `correctly navigates to `Home`.
- Ensured that the `Back button` in `Preview` still functions as expected.
- Tested across different navigation flows to confirm consistency and reliability.