### PR TITLE
fix:rerouted logout router push from signin page back to landing page

### DIFF
--- a/src/app/(auth)/components/protected-route.tsx
+++ b/src/app/(auth)/components/protected-route.tsx
@@ -16,8 +16,8 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (isHydrated && !token) {
-      toast.error("Please sign in");
-      router.push("/signin");
+      toast.error("You're signed out");
+      router.push("/");
     }
   }, [token, router, isHydrated]);
 


### PR DESCRIPTION
Fix- changed the toast error and re routed the push to take users back to the landing page after signout (as commented by the graders).