### PR TITLE
fix: display ad size in details and clean up image source logic

### DIFF
--- a/src/app/(dashboard)/dashboard/details/page.tsx
+++ b/src/app/(dashboard)/dashboard/details/page.tsx
@@ -107,7 +107,9 @@ const AddDetails = () => {
         </div>
         <div>
           <p className="text-[#121316]">Ad Size & Format</p>
-          <span className="text-[#5F5F5F] font-medium">{"Facebook"}</span>
+          <span className="text-[#5F5F5F] font-medium">
+            {pageAdData.ad_size || ""}
+          </span>
         </div>
         <div>
           <p className="text-[#121316]">Target Audience</p>
@@ -136,15 +138,17 @@ const AddDetails = () => {
             filter={filter}
           />
         </div>
-        <div className="md:my-10 py-3 bg-[#F0F3F5] rounded-lg md:p-10  max-w-[699px] w-full max-md:w-[90%] flex items-center justify-center " >
+        <div className="md:my-10 py-3 bg-[#F0F3F5] rounded-lg md:p-10  max-w-[699px] w-full max-md:w-[90%] flex items-center justify-center ">
           <Image
-            src={pageAdData.final_url? pageAdData.final_url : pageAdData.image_url} 
+            src={
+              pageAdData.final_url ? pageAdData.final_url : pageAdData.image_url
+            }
             height={310}
             width={335}
             alt={"ad Image"}
             className="w-full h-auto rounded-lg bg-transparent"
             unoptimized
-            id='containerRef'
+            id="containerRef"
           />
         </div>
       </section>

--- a/src/domains/ads-gen/context/AdsContext.tsx
+++ b/src/domains/ads-gen/context/AdsContext.tsx
@@ -13,6 +13,7 @@ export interface Ad {
   target_audience: string;
   updated_at: string;
   product_name: string;
+  ad_size: string;
 }
 interface Ads {
   user: Ad[];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The ad size and format displayed in the dashboard now dynamically reflect the actual ad size from your data, rather than showing a fixed value.

- **Style**
  - Improved consistency in the display and formatting of ad details for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->